### PR TITLE
chore(deps): bump copier project template to v0.4.3-43-g2e70cbc

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.4.3-41-gfae22e5
+_commit: v0.4.3-43-g2e70cbc
 _src_path: git+https://github.com/twsl/python-project-template
 author_email: 45483159+twsl@users.noreply.github.com
 author_username: twsl

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,5 +6,6 @@
 *.c text
 *.h text
 
-# Declare files that will always have CRLF line endings on checkout.
+# Declare files that will always have lf line endings on checkout.
 *.py text eol=lf
+*.sh text eol=lf

--- a/scripts/llm.sh
+++ b/scripts/llm.sh
@@ -4,6 +4,7 @@ curl -fsSL https://gh.io/copilot-install | bash
 curl -fsSL https://claude.ai/install.sh | bash
 curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_NON_INTERACTIVE=1 bash
 
+export PATH="$HOME/.local/bin:$PATH"
 curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | bash
 
 curl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh | bash


### PR DESCRIPTION
This PR updates files via copier. In case of conflicts, the PR will always reflect the latest copier output.